### PR TITLE
Li Tieg updates: A few new pieces of medical gear, clothing changed

### DIFF
--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -21,6 +21,13 @@
 /obj/machinery/suit_storage_unit/inherit,
 /turf/open/floor/plasteel,
 /area/ship/storage)
+"bc" = (
+/obj/effect/turf_decal/trimline/opaque/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/medical_kiosk,
+/turf/open/floor/plasteel,
+/area/ship/hallway/aft)
 "bl" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -192,15 +199,9 @@
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/shoes/combat,
-/obj/item/clothing/under/rank/security/brig_phys,
-/obj/item/clothing/under/rank/security/brig_phys,
-/obj/item/clothing/under/rank/security/brig_phys,
 /obj/item/clothing/suit/toggle/labcoat/paramedic,
 /obj/item/clothing/suit/toggle/labcoat/paramedic,
 /obj/item/clothing/suit/toggle/labcoat/paramedic,
-/obj/item/clothing/head/soft/paramedic,
-/obj/item/clothing/head/soft/paramedic,
-/obj/item/clothing/head/soft/paramedic,
 /obj/item/storage/backpack/ert/medical,
 /obj/item/storage/backpack/ert/medical,
 /obj/item/storage/backpack/ert/medical,
@@ -214,6 +215,15 @@
 	pixel_x = 28;
 	req_access_txt = "5"
 	},
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/clothing/under/syndicate/medic/trauma,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "eS" = (
@@ -278,6 +288,12 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "gL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/hallway/aft)
+"gN" = (
+/obj/machinery/vending/wallmed{
+	pixel_w = 0.5
+	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/aft)
 "gO" = (
@@ -387,11 +403,6 @@
 /obj/item/healthanalyzer/advanced,
 /obj/item/healthanalyzer/advanced,
 /obj/item/healthanalyzer/advanced,
-/obj/item/storage/belt/medical/surgery,
-/obj/item/storage/belt/medical/paramedic,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/gloves/color/latex/nitrile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -409,6 +420,12 @@
 	pixel_x = -28;
 	req_access_txt = "5"
 	},
+/obj/item/clothing/gloves/color/latex/nitrile/evil,
+/obj/item/clothing/gloves/color/latex/nitrile/evil,
+/obj/item/clothing/gloves/color/latex/nitrile/evil,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/storage/belt/medical/webbing,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "kH" = (
@@ -543,18 +560,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet{
-	icon_state = "med";
-	name = "medicine locker"
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/box/medipens,
-/obj/item/storage/box/syringes,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
+/obj/machinery/vending/medical,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "nl" = (
@@ -853,6 +859,16 @@
 /obj/item/clothing/shoes/sneakers/blue,
 /obj/item/clothing/shoes/sneakers/blue,
 /obj/item/clothing/shoes/sneakers/blue,
+/obj/item/storage/belt/medical/webbing,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/head/soft/cybersun/trauma,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
+/obj/item/clothing/under/rank/medical/chemist/junior_chemist,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "tT" = (
@@ -1235,6 +1251,8 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/gloves,
 /obj/item/storage/box/masks,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "DU" = (
@@ -1602,7 +1620,6 @@
 /obj/item/clothing/suit/toggle/labcoat/cmo,
 /obj/item/clothing/shoes/sneakers/white,
 /obj/item/clothing/glasses/hud/health/sunglasses,
-/obj/item/storage/belt/medical,
 /obj/item/clothing/neck/tie/light_blue,
 /obj/item/healthanalyzer/advanced,
 /obj/item/hypospray/mkii/CMO,
@@ -1615,6 +1632,12 @@
 	},
 /obj/item/storage/backpack/satchel/med,
 /obj/item/gun/energy/e_gun/mini,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/gloves/color/latex/nitrile/evil,
+/obj/item/clothing/under/syndicate/medic/trauma,
+/obj/item/storage/belt/medical/webbing/paramedic,
+/obj/item/clothing/head/soft/cybersun/trauma,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
 "Ny" = (
@@ -1846,6 +1869,8 @@
 /obj/structure/bed,
 /obj/structure/curtain/bounty,
 /obj/item/bedsheet/cmo,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "SP" = (
@@ -1979,6 +2004,7 @@
 /obj/item/stack/spacecash/c1000,
 /obj/item/stack/spacecash/c1000,
 /obj/item/stack/spacecash/c1000,
+/obj/item/clothing/under/syndicate/medic/trauma,
 /turf/open/floor/carpet/nanoweave,
 /area/ship/bridge)
 "UO" = (
@@ -2032,6 +2058,7 @@
 	pixel_x = -28;
 	req_access_txt = "5"
 	},
+/obj/item/clothing/head/helmet/sec,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Vq" = (
@@ -2495,7 +2522,7 @@ YM
 gL
 Rh
 gL
-gL
+gN
 gL
 AJ
 "}
@@ -2579,7 +2606,7 @@ YK
 RW
 dH
 uq
-ur
+bc
 go
 Bl
 Bl

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -1613,7 +1613,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
 "Nq" = (
-/obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/under/suit/cmo,
 /obj/item/clothing/suit/toggle/labcoat/cmo,
 /obj/item/clothing/shoes/sneakers/white,
@@ -1631,7 +1630,6 @@
 /obj/item/storage/backpack/satchel/med,
 /obj/item/gun/energy/e_gun/mini,
 /obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/gloves/color/latex/nitrile/evil,
 /obj/item/clothing/under/syndicate/medic/trauma,
 /obj/item/storage/belt/medical/webbing/paramedic,

--- a/_maps/shuttles/shiptest/independent_litieguai.dmm
+++ b/_maps/shuttles/shiptest/independent_litieguai.dmm
@@ -291,9 +291,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/aft)
 "gN" = (
-/obj/machinery/vending/wallmed{
-	pixel_w = 0.5
-	},
+/obj/machinery/vending/wallmed,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/aft)
 "gO" = (

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -143,6 +143,13 @@
 	soft_type = "cybersun"
 	dog_fashion = null
 
+/obj/item/clothing/head/soft/cybersun/trauma
+	name = "Trauma Team medic cap"
+	desc = "A turquoise baseball hat emblazoned with a reflective cross. Commonly seen worn by Trauma Team Technicians. 3 minute response time not guaranteed."
+	icon_state = "cybersunsoft"
+	soft_type = "cybersun"
+	dog_fashion = null
+
 /obj/item/clothing/head/soft/inteq
 	name = "inteq utility cover"
 	desc = "A drab brown utility cover with a golden insignia on it. Worn by IRMG operators."

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -139,6 +139,13 @@
 	permeability_coefficient = 0.5
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
+/obj/item/clothing/under/syndicate/medic/trauma
+	name = "Trauma Team medical jumpsuit"
+	desc = "Sterile coveralls worn by Trauma Team Technicians for protection against biological hazards. Heal. Diagnose. Extract."
+	icon_state = "cybersun_med"
+	permeability_coefficient = 0.5
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/under/syndicate/medic/skirt
 	name = "Cybersun medical jumpskirt"
 	desc = "A sterile jumpskirt worn by Cybersun Industries field medics for protection against biological hazards."

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -64,7 +64,7 @@
 
 	uniform = /obj/item/clothing/under/syndicate/medic/trauma
 	head = /obj/item/clothing/head/soft/paramedic
-	belt = 	belt = /obj/item/storage/belt/medical/webbing/paramedic
+	belt = /obj/item/storage/belt/medical/webbing/paramedic
 	shoes = /obj/item/clothing/shoes/combat
 	backpack = /obj/item/storage/backpack/ert/medical
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -63,7 +63,7 @@
 	name = "Paramedic (Trauma Team Technician)"
 
 	uniform = /obj/item/clothing/under/syndicate/medic/trauma
-	head = /obj/item/clothing/head/soft/paramedic
+	head = /obj/item/clothing/head/soft/cybersun/trauma
 	belt = /obj/item/storage/belt/medical/webbing/paramedic
 	shoes = /obj/item/clothing/shoes/combat
 	backpack = /obj/item/storage/backpack/ert/medical

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -64,10 +64,12 @@
 
 	uniform = /obj/item/clothing/under/syndicate/medic/trauma
 	head = /obj/item/clothing/head/soft/paramedic
-	belt = /obj/item/storage/belt/medical/webbing
+	belt = 	belt = /obj/item/storage/belt/medical/webbing/paramedic
 	shoes = /obj/item/clothing/shoes/combat
 	backpack = /obj/item/storage/backpack/ert/medical
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil
+	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
+
 /datum/outfit/job/paramedic/syndicate/gorlex
 	name = "Paramedic (Gorlex)"
 

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -62,9 +62,12 @@
 /datum/outfit/job/paramedic/traumateam
 	name = "Paramedic (Trauma Team Technician)"
 
-	uniform = /obj/item/clothing/under/rank/security/brig_phys
+	uniform = /obj/item/clothing/under/syndicate/medic/trauma
+	head = /obj/item/clothing/head/soft/paramedic
+	belt = /obj/item/storage/belt/medical/webbing
 	shoes = /obj/item/clothing/shoes/combat
 	backpack = /obj/item/storage/backpack/ert/medical
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile/evil
 /datum/outfit/job/paramedic/syndicate/gorlex
 	name = "Paramedic (Gorlex)"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The Li Tieg has been changed in terms of equipment. Medical belts and other clothing are replaced with their Trauma Team equivalents, while equipment and guns have remained relatively unchanged.
Images of changes:
![image](https://user-images.githubusercontent.com/81567866/192662213-ad14793e-e3f1-46f0-924b-02f7bcb57902.png)
![image](https://user-images.githubusercontent.com/81567866/192664329-61923c1d-a2a8-4fc9-8108-98077508bb20.png)
![image](https://user-images.githubusercontent.com/81567866/192664343-e445de76-4d4b-4bea-b51a-6c5d33462d72.png)

Captain wearing the TT jumpsuit: 
![image](https://user-images.githubusercontent.com/81567866/192663599-2f740e04-eb68-4552-ab24-47e668d86776.png)
CMO wearing the TT jumpsuit, hat and gloves:
![image](https://user-images.githubusercontent.com/81567866/192663821-14800326-fa4a-4363-9909-ef84eeb8d656.png)
TTT wearing the TT jumpsuit, hat and gloves: 
![image](https://user-images.githubusercontent.com/81567866/192664010-0dc12471-b40d-495a-b624-4a17c5bf0140.png)
MI wearing the TT jumpsuit and hat: 
![image](https://user-images.githubusercontent.com/81567866/192664061-c5eb720a-bca7-4c0d-96a1-46e42abf80ae.png)
.. and also the Jr. Chemist jumpsuit:
![image](https://user-images.githubusercontent.com/81567866/192664139-b0db03cd-b9b9-4bbd-b0e1-79cbb939db5b.png)

Full list of changes:
Added 6 trauma team caps to the medical intern's locker.
Added 3 medical webbings to the medical intern's locker.
Gave the Captain locker and the CMO locker one trauma team cap and one jumpsuit.
Gave the CMO locker a medical webbing and red nitrile gloves.
Gave the equipment locker 3 red nitrile gloves, 3 medical webbings.
Gave the clothing locker 3 trauma team caps, and 6 trauma team jumpsuits.
Replaced the medkit crate with a nanomed; added a syringe box to the secure medical locker.
Added a wall mounted nanomed to the lobby.
Added a medical kiosk to the lobby. Now you really have that medical receptionist feel!
Trauma team technicians now get medHUD sunglasses, their trauma team uniforms and caps, as well as medical webbing and red nitrile gloves.
Added 3 junior chemist jumpsuits to the medical intern's locker.

<!-- Tick the box below (put an X instead of a space between the brackets) if you have tested your changes and this is ready for review. Leave unticked if you have yet to test your changes and this is not ready for review. -->

- [x] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Cybersun equipment really isn't seen much, it's only on one ship, and the Li Tieg could use some tweaks.
..Plus, it's called Trauma Team Technician yet there's no Trauma Team colors? This is a nice way to add some more style to the Li Tieg.


## Changelog

:cl:
tweak: Replaced the various nitrile gloves, belts and jumpsuits with their Trauma Team variants on the Li Tieguai.
add: Added a nanomed in place of the medical kit crate on the Li Tieg.
add: Added Trauma Team (cybersun subtype) clothes and red nitrile gloves to the Li Tieg, along with their hats.
add: Added a wall-mounted nanomed to the Li Tieg
add: Added some junior chemist clothes to the medical intern locker of the Li Tieg.
del: Removed the medical kit crate from the Li Tieg
tweak: Trauma Team Technicians on the Midway and the Li Tieguai come with Trauma Team gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
